### PR TITLE
Persisting records to disk by implementing aof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.dll
 *.so
 *.dylib
+*.DS_Store
+*.aof
 
 # Test binary, built with `go test -c`
 *.test

--- a/main.go
+++ b/main.go
@@ -8,6 +8,8 @@ import (
 func main() {
 	fmt.Println("Listening on port 6379")
 
-	server := pedis.NewServer()
+	server := pedis.NewServer(&pedis.Config{
+		EnableAof: true,
+	})
 	server.ListenAndServe("0.0.0.0:6379")
 }

--- a/pedis/aof.go
+++ b/pedis/aof.go
@@ -1,0 +1,143 @@
+package pedis
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+type Aof struct {
+	f      *os.File
+	mx     sync.Mutex
+	closed bool
+	rd     *Reader
+	atEnd  bool
+}
+
+func (a *Aof) ReadValues(iterator func(Value) bool) error {
+	a.atEnd = false
+	if _, err := a.f.Seek(0, 0); err != nil {
+		return err
+	}
+
+	rd := NewReader(a.f)
+	for {
+		v, err := rd.resp.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			fmt.Println("Error from readvalues: ", err)
+			return err
+		}
+
+		if iterator != nil && !iterator(v) {
+			return nil
+		}
+	}
+
+	_, err := a.f.Seek(0, 2) // seek to the end of the file
+	if err != nil {
+		return err
+	}
+
+	a.atEnd = true
+	return nil
+}
+
+func NewAof(path string) (*Aof, error) {
+	if path == "" {
+		// create aof file in the current directory
+		path = "pedis.aof"
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0666)
+	if err != nil {
+		return nil, err
+	}
+
+	aof := &Aof{
+		f:  f,
+		rd: NewReader(f),
+	}
+
+	// start a goroutine to flush the buffer to disk every 1 second
+	// this might change in the future when we want to have more policies
+	// on how to write aof to disk.
+	go func() {
+		for {
+			aof.mx.Lock()
+			if aof.closed {
+				aof.mx.Unlock()
+				return
+			}
+
+			aof.f.Sync()
+
+			aof.mx.Unlock()
+
+			time.Sleep(time.Second)
+		}
+	}()
+
+	return aof, nil
+}
+
+func (a *Aof) Close() error {
+	a.mx.Lock()
+	defer a.mx.Unlock()
+
+	a.closed = true
+
+	return a.f.Close()
+}
+
+func (a *Aof) Write(b []byte) (int, error) {
+	a.mx.Lock()
+	defer a.mx.Unlock()
+
+	return a.f.Write(b)
+}
+
+func (a *Aof) Append(val Value) error {
+	return a.AppendMany([]Value{val})
+}
+
+func (a *Aof) AppendMany(vals []Value) error {
+	var bs []byte
+	for _, val := range vals {
+		bytes, err := val.MarshalResp()
+		if err != nil {
+			return err
+		}
+
+		if bs == nil {
+			bs = bytes
+		} else {
+			bs = append(bs, bytes...)
+		}
+	}
+
+	a.mx.Lock()
+	defer a.mx.Unlock()
+
+	if a.closed {
+		return errors.New("Aof file is closed")
+	}
+
+	if !a.atEnd {
+		// todo: read the records to the end of the file instead of seeking here
+		a.f.Seek(0, io.SeekEnd) // jump to the end of the file
+		a.atEnd = true
+	}
+
+	_, err := a.f.Write(bs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pedis/handlers.go
+++ b/pedis/handlers.go
@@ -1,18 +1,31 @@
 package pedis
 
-var defaultHandlers = map[string]func(conn *Conn, args []Value) bool{
-	"PING":    pingHandler,
-	"SET":     SetHandler,
-	"GET":     GetHandler,
-	"DEL":     DelHandler,
-	"EXISTS":  ExistsHandler,
-	"HSET":    HSetHandler,
-	"HGET":    HGetHandler,
-	"HGETALL": HGetAllHandler,
-	"HDEL":    HDelHandler,
-	"HLEN":    HLenHandler,
-	"HKEYS":   HKeysHandler,
-	"HVALS":   HValsHandler,
+type CommandHandler struct {
+	Handler func(conn *Conn, args []Value) bool
+	persist bool
+}
+
+func (h *CommandHandler) should_persist() bool {
+	return h.persist
+}
+
+func (h *CommandHandler) call(conn *Conn, args []Value) bool {
+	return h.Handler(conn, args)
+}
+
+var defaultHandlers = map[string]CommandHandler{
+	"PING":    CommandHandler{pingHandler, false},
+	"SET":     CommandHandler{SetHandler, true},
+	"GET":     CommandHandler{GetHandler, false},
+	"DEL":     CommandHandler{DelHandler, true},
+	"EXISTS":  CommandHandler{ExistsHandler, false},
+	"HSET":    CommandHandler{HSetHandler, true},
+	"HGET":    CommandHandler{HGetHandler, false},
+	"HGETALL": CommandHandler{HGetAllHandler, false},
+	"HDEL":    CommandHandler{HDelHandler, true},
+	"HLEN":    CommandHandler{HLenHandler, false},
+	"HKEYS":   CommandHandler{HKeysHandler, false},
+	"HVALS":   CommandHandler{HValsHandler, false},
 }
 
 func pingHandler(conn *Conn, args []Value) bool {

--- a/pedis/server.go
+++ b/pedis/server.go
@@ -140,7 +140,7 @@ func (s *Server) ListenAndServe(addr string) error {
 					return
 				}
 
-				fmt.Println(err)
+				panic(err)
 			}
 		}()
 	}

--- a/pedis/server.go
+++ b/pedis/server.go
@@ -24,25 +24,39 @@ func NewConn(conn net.Conn) *Conn {
 	}
 }
 
-type Server struct {
-	mu       sync.RWMutex
-	handlers map[string]func(conn *Conn, args []Value) bool
-	accept   func(conn *Conn) bool
+type Config struct {
+	EnableAof bool
+	AofFile   string
 }
 
-func NewServer() *Server {
-	handlers := make(map[string]func(conn *Conn, args []Value) bool)
+type Server struct {
+	mu       sync.RWMutex
+	handlers map[string]CommandHandler
+	accept   func(conn *Conn) bool
+	config   *Config
+	Aof      *Aof
+}
+
+func NewServer(config *Config) *Server {
+	handlers := make(map[string]CommandHandler)
 
 	for command, handler := range defaultHandlers {
 		handlers[strings.ToUpper(command)] = handler
 	}
 
-	return &Server{
+	s := &Server{
 		handlers: handlers,
+		config:   config,
 	}
+
+	if config.EnableAof {
+		bootstrapAof(s)
+	}
+
+	return s
 }
 
-func (s *Server) HandleFunc(command string, handler func(conn *Conn, args []Value) bool) {
+func (s *Server) HandleFunc(command string, handler CommandHandler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.handlers[strings.ToUpper(command)] = handler
@@ -77,9 +91,9 @@ func (s *Server) handleConn(conn net.Conn) error {
 			continue
 		}
 
-		commands := value.Array()
+		request := value.Array()
 
-		command := strings.ToUpper(commands[0].String())
+		command := strings.ToUpper(request[0].String())
 
 		s.mu.RLock()
 		handler, ok := s.handlers[command]
@@ -93,8 +107,14 @@ func (s *Server) handleConn(conn net.Conn) error {
 			continue
 		}
 
-		if !handler(c, commands[1:]) {
+		if !handler.call(c, request[1:]) {
 			return nil
+		}
+
+		if s.Aof != nil && handler.should_persist() {
+			if err := s.Aof.Append(value); err != nil {
+				return err
+			}
 		}
 	}
 }
@@ -120,8 +140,40 @@ func (s *Server) ListenAndServe(addr string) error {
 					return
 				}
 
-				panic(err)
+				fmt.Println(err)
 			}
 		}()
 	}
+}
+
+func bootstrapAof(s *Server) {
+	aof, err := NewAof(s.config.AofFile)
+	if err != nil {
+		panic(err)
+	}
+
+	s.Aof = aof
+
+	aof.ReadValues(func(value Value) bool {
+		commands := value.Array()
+
+		command := strings.ToUpper(commands[0].String())
+
+		s.mu.RLock()
+		handler, ok := s.handlers[command]
+		s.mu.RUnlock()
+
+		if !ok {
+			return true
+		}
+
+		// create fake connection with fake writer
+		conn := &Conn{
+			Writer: NewWriter(io.Discard),
+		}
+
+		handler.call(conn, commands[1:])
+
+		return true
+	})
 }


### PR DESCRIPTION
Implemented (Append only file) that logs every write operation received by the server. these operations will be replayed again on server startup. commands are logged using the same format as the Redis protocol itself.

Also there is a new config struct to make it easy to enable/disable AOF on server startup
```go
func main() {
	fmt.Println("Listening on port 6379")

	server := pedis.NewServer(&pedis.Config{
		EnableAof: true,
                AofFile:   "pedis.aof", // optional
	})
	server.ListenAndServe("0.0.0.0:6379")
}
```